### PR TITLE
Correct ambiguous 'ls' command

### DIFF
--- a/src/ch02.t
+++ b/src/ch02.t
@@ -665,9 +665,9 @@ oldstuff/
 notes
 reports/
 $ \f[CB]mv notes oldstuff\fP     \f[I]Move\fP notes \f[I]to\fP oldstuff \f[I]directory\fP
-$ \f[CB]ls\fP                    \f[I]List contents of current directory\fP
+$ \f[CB]ls -F\fP                 \f[I]List contents of current directory\fP
 meeting
-oldstuff
+oldstuff/
 reports/
 $ \f[CB]mv meeting meet.306\fP   \f[I]Rename\fP meeting
 $ \f[CB]ls oldstuff\fP           \f[I]List contents of\fP oldstuff \f[I]subdirectory\fP


### PR DESCRIPTION
In the "Copying and Moving Files" section the '-F' option is passed to 'ls' to show two files and two directories.  The next command moves one of the files to a directory and the following example shows a bare 'ls' but with one of the directories with a trailing '/' character (the result of the '-F' option).

This patch removes the ambiguity by showing the result when '-F' is passed to 'ls' by adding the option to the command and showing both directories with trailing '/' characters.

This ambiguity is also present in the original book available from: https://www.oreilly.com/openbook/utp/