### PR TITLE
Some hotlinks land on previous page.

### DIFF
--- a/src/utp_book.t
+++ b/src/utp_book.t
@@ -16,6 +16,7 @@
 .pdfinfo /Title Unix Text Processing
 .pdfinfo /Author Dale Dougherty and Tim O'Reilly
 .pdfview /PageMode /UseOutlines
+.if d @break-page .als bp @break-page
 .nr chapter_page2 1
 .so front.t
 .nr chapter_page2 1


### PR DESCRIPTION
If you run with groff later than 1.23.0 top-level hot-links in the overview panel and the TOC, jump to the page before the title they refer to.

* utp_book.t: Use real '.bp' not "soft" version introduced by this [commit](https://cgit.git.savannah.gnu.org/cgit/groff.git/commit/?id=5808f3f4dd8f39341170597363a6aaf7acf921fd).